### PR TITLE
fix: LayoutWithFooter를 UserRouter, AuthRouter의 하위로 이동

### DIFF
--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -39,15 +39,17 @@ const Router = () => {
           <Route index path={PATH.root} element={<MainPage />} />
         </Route>
 
-        <Route element={<LayoutWithoutFooter />}>
-          <Route element={<AuthRouter />}>
+        <Route element={<AuthRouter />}>
+          <Route element={<LayoutWithoutFooter />}>
             <Route path={PATH.login} element={<LoginPage />} />
             <Route path={PATH.register} element={<RegisterPage />} />
             <Route path={PATH.kakao} element={<KakaoCallbackPage />} />
             <Route path={PATH.naver} element={<NaverCallbackPage />} />
           </Route>
+        </Route>
 
-          <Route element={<UserRouter />}>
+        <Route element={<UserRouter />}>
+          <Route element={<LayoutWithoutFooter />}>
             <Route path={PATH.recipeWrite} element={<RecipeWritePage />} />
             <Route path={RECIPE_PATH.edit} element={<RecipeEditPage />} />
             <Route path={PATH.talkWrite} element={<TalkWritePage />} />
@@ -56,7 +58,9 @@ const Router = () => {
             <Route path={PATH.myPosts} element={<MyPosts />} />
             <Route path={PATH.myBookmark} element={<MyBookmark />} />
           </Route>
+        </Route>
 
+        <Route element={<LayoutWithoutFooter />}>
           <Route path={RECIPE_PATH.detail} element={<RecipeDetailPage />} />
           <Route path={ROOM_PATH.detail} element={<RoomDetailPage />} />
           <Route path={TALK_PATH.detail} element={<TalkDetailPage />} />


### PR DESCRIPTION
AuthRouter 혹은 UserRouter로 로그인 상태를 확인한 후, 레이아웃(LayoutWithoutFooter)이 보이도록 변경했습니다.

다양한 Layout을 한 파일(Router.tsx)에서 관리하도록 하고 싶어서, 아래의 두 가지 방법 중 첫 번째 방법을 적용했습니다.
  1. 현재 Router파일에서 AuthRouter, UserRouter 하위에 각각 LayoutWithoutFooter로 감싸주거나
  2. AuthRouter, UserRouter 파일의 Outlet요소를 LayoutWithoutFooter로 감싸주는 것도 방법일 것 같습니다!