### PR TITLE
방자랑 리팩토링

### DIFF
--- a/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
+++ b/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
@@ -3,7 +3,7 @@ import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { CarouselItem } from '@/components/ui/carousel';
 import { Card, CardContent } from '@/components/ui/card';
-import { CirclePlus, CircleX, Image } from 'lucide-react';
+import { CircleX, Image, ImagePlus } from 'lucide-react';
 
 interface RoomImagesFieldsType {
   roomImages: {
@@ -96,10 +96,10 @@ const RoomImagesFields = () => {
         <div className="p-1">
           <Card>
             <CardContent
-              className="flex aspect-square items-center justify-center cursor-pointer group"
+              className="flex aspect-square items-center justify-center cursor-pointer group pb-0"
               onClick={() => append({ image: {} as File, imageUrl: '' })}
             >
-              <CirclePlus size={64} color="#a0aec0" strokeWidth={2} className=" group-hover:stroke-[#2d3748]" />
+              <ImagePlus size={64} color="#a0aec0" strokeWidth={2} className=" group-hover:stroke-[#2d3748]" />
             </CardContent>
           </Card>
         </div>

--- a/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
+++ b/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
@@ -47,6 +47,13 @@ const RoomImagesFields = () => {
     }
   }, [fields, appendedIndex]);
 
+  //  const handleAppend = () => {
+  //   append({ image: {} as File, imageUrl: '' });
+  //   setTimeout(() => {
+  //     fileInputRefs.current[fileInputRefs.current.length - 1]?.click();
+  //   }, 0);
+  // };
+
   return (
     <>
       {fields?.map((item, i) => (

--- a/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
+++ b/src/pages/RoomWrite/components/RoomImagesFields/RoomImagesFields.tsx
@@ -1,4 +1,4 @@
-import { useRef, ChangeEvent } from 'react';
+import { useRef, ChangeEvent, useState, useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { Button } from '@/components/ui/button';
 import { CarouselItem } from '@/components/ui/carousel';
@@ -21,6 +21,7 @@ const RoomImagesFields = () => {
   });
 
   const fileInputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const [appendedIndex, setAppendedIndex] = useState<number | null>(null);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
     const { files } = e.target;
@@ -32,6 +33,19 @@ const RoomImagesFields = () => {
       setValue(`roomImages.${index}.imageUrl`, imageUrl);
     }
   };
+
+  const handleAppend = () => {
+    const newIndex = fields.length;
+    append({ image: {} as File, imageUrl: '' });
+    setAppendedIndex(newIndex);
+  };
+
+  useEffect(() => {
+    if (appendedIndex !== null && fileInputRefs.current[appendedIndex]) {
+      fileInputRefs.current[appendedIndex]?.click();
+      setAppendedIndex(null);
+    }
+  }, [fields, appendedIndex]);
 
   return (
     <>
@@ -97,7 +111,7 @@ const RoomImagesFields = () => {
           <Card>
             <CardContent
               className="flex aspect-square items-center justify-center cursor-pointer group pb-0"
-              onClick={() => append({ image: {} as File, imageUrl: '' })}
+              onClick={handleAppend}
             >
               <ImagePlus size={64} color="#a0aec0" strokeWidth={2} className=" group-hover:stroke-[#2d3748]" />
             </CardContent>

--- a/src/services/room/useRoomEditMutation.tsx
+++ b/src/services/room/useRoomEditMutation.tsx
@@ -1,0 +1,43 @@
+import { CheckCircle, CircleXIcon } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useToast } from '@/hooks/useToast';
+import { TOAST } from '@/constants/toast';
+
+import { roomEditPatchFetch, RoomEditPatchFetchParams } from '@/api/room/roomEditPatchFetch';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/paths';
+
+/**
+ * 내가 작성한 방자랑 수정
+ */
+export const useRoomEditMutation = () => {
+  const { toast } = useToast();
+
+  const navigate = useNavigate();
+
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (params: RoomEditPatchFetchParams) => roomEditPatchFetch(params),
+    onSuccess: (response) => {
+      toast({
+        title: '방자랑이 수정되었습니다.',
+        icon: <CheckCircle />,
+        className: TOAST.success,
+      });
+      navigate(`${PATH.room}/${response.data.id}`);
+      queryClient.invalidateQueries({ queryKey: ['@roomList'] });
+    },
+    onError: (error) => {
+      console.error('방자랑 수정 실패', error);
+
+      toast({
+        title: '방자랑 수정을 실패했습니다.',
+        icon: <CircleXIcon />,
+        className: TOAST.error,
+      });
+    },
+  });
+  return mutation;
+};

--- a/src/services/room/useRoomWriteMutation.tsx
+++ b/src/services/room/useRoomWriteMutation.tsx
@@ -1,0 +1,43 @@
+import { CheckCircle, CircleXIcon } from 'lucide-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useToast } from '@/hooks/useToast';
+import { TOAST } from '@/constants/toast';
+
+import { writeRoomPostFetch, WriteRoomPostFetchParams } from '@/api/room/writeRoomPostFetch';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '@/constants/paths';
+
+/**
+ * 방자랑 작성
+ */
+export const useRoomWriteMutation = () => {
+  const { toast } = useToast();
+
+  const navigate = useNavigate();
+
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (params: WriteRoomPostFetchParams) => writeRoomPostFetch(params),
+    onSuccess: (response) => {
+      toast({
+        title: '방자랑이 작성되었습니다.',
+        icon: <CheckCircle />,
+        className: TOAST.success,
+      });
+      navigate(`${PATH.room}/${response.data.id}`);
+      queryClient.invalidateQueries({ queryKey: ['@roomList'] });
+    },
+    onError: (error) => {
+      console.error('방자랑 작성 실패', error);
+
+      toast({
+        title: '방자랑 작성을 실패했습니다.',
+        icon: <CircleXIcon />,
+        className: TOAST.error,
+      });
+    },
+  });
+  return mutation;
+};


### PR DESCRIPTION
- [방자랑] 이미지 추가 depth 줄이기
  - 방자랑 등록 중 uploadImage 파이어베이스 storage에 이미지를 올리는 요청에서 에러 발생했지만, 개인 파이어베이스 key 설정으로 테스트 확인 완료!
- [방자랑] react query 뮤테이션 적용하기
  - queryClient.invalidateQueries 를 설정해 작성/수정 완료 시 페이지가 이동될 때, 컨텐츠가 렌더링에 바로 반영된 걸 확인할 수 있었다.
  - 그리고 방자랑 페이지 컴포넌트가 아니라 뮤테이션 파일 내부에서 각 요청에 따라 성공, 실패 시 toast를 구현함으로써 코드를 분리할 수 있었다.